### PR TITLE
docs(readme): add dependents info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Run tests](https://github.com/chris48s/geojson-rewind/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/chris48s/geojson-rewind/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/chris48s/geojson-rewind/branch/master/graph/badge.svg?token=0WGM3W8ULH)](https://codecov.io/gh/chris48s/geojson-rewind)
 ![PyPI Version](https://img.shields.io/pypi/v/geojson-rewind.svg)
+[![Network Dependents](https://dependents.info/chris48s/geojson-rewind/badge)](https://dependents.info/chris48s/geojson-rewind)
 ![License](https://img.shields.io/pypi/l/geojson-rewind.svg)
 ![Python Compatibility](https://img.shields.io/badge/dynamic/json?query=info.requires_python&label=python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fgeojson-rewind%2Fjson)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
@@ -16,6 +17,12 @@ The [GeoJSON](https://tools.ietf.org/html/rfc7946) spec mandates the [right hand
 This helps you generate compliant Polygon and MultiPolygon geometries.
 
 Note: Co-ordinates in the input data are assumed to be WGS84 with (lon, lat) ordering, [as per RFC 7946](https://tools.ietf.org/html/rfc7946#section-3.1.1). Input with co-ordinates using any other CRS may lead to unexpected results.
+
+## Used by
+
+<a href="https://dependents.info/chris48s/geojson-rewind">
+  <img src="https://dependents.info/chris48s/geojson-rewind/image" />
+</a>
 
 ## Installation
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago: [dependents.info](https://dependents.info).

Here's how they would look for your repository:

<img width="625" alt="image" src="https://github.com/user-attachments/assets/d5798656-3660-4e99-b2cf-0b4b3feeb85d" />

Please feel free to close the PR if you don't want to have this!